### PR TITLE
ENH: Use different binary folders for Continuous and Nightly

### DIFF
--- a/Eternia_Kitware_TubeTK.cmake
+++ b/Eternia_Kitware_TubeTK.cmake
@@ -34,7 +34,7 @@ set( SITE_CMAKE_GENERATOR "Unix Makefiles" )
 set( TubeTK_GIT_REPOSITORY "https://github.com/TubeTK/TubeTK.git" )
 set( TubeTK_SOURCE_DIR "/home/aylward/src/dashboards/TubeTK" )
 set( TubeTK_BINARY_DIR
-  "/home/aylward/src/dashboards/TubeTK-${SITE_BUILD_TYPE}" )
+  "/home/aylward/src/dashboards/TubeTK-${SITE_CTEST_MODE}-${SITE_BUILD_TYPE}" )
 
 set( TubeTK_USE_BOOST ON )
 set( BOOST_ROOT "/home/aylward/src/boost_1_54_0" )

--- a/Eternia_Kitware_TubeTK_Nightly.sh
+++ b/Eternia_Kitware_TubeTK_Nightly.sh
@@ -9,7 +9,8 @@ echo "Running TubeTK Dashboard script"
 if [ $# -eq 0 ] || [ "$1" != "NoUpdate" ]; then
 
   echo "Updating"
-  rm -rf ${DashboardDir}/TubeTK-${BuildType}
+  rm -rf ${DashboardDir}/TubeTK-Nightly-${BuildType}
+  rm -rf ${DashboardDir}/TubeTK-Continuous-${BuildType}
 
   # Update Dashboard repository
   cd ${DashboardDir}/TubeTK-DashboardScripts

--- a/Krull_Kitware_TubeTK.cmake
+++ b/Krull_Kitware_TubeTK.cmake
@@ -33,7 +33,7 @@ set( SITE_CMAKE_GENERATOR "Unix Makefiles" )
 
 set( TubeTK_GIT_REPOSITORY "https://github.com/TubeTK/TubeTK.git" )
 set( TubeTK_SOURCE_DIR "/home/aylward/src/dashboards/TubeTK" )
-set( TubeTK_BINARY_DIR "/home/aylward/src/dashboards/TubeTK-${SITE_BUILD_TYPE}" )
+set( TubeTK_BINARY_DIR "/home/aylward/src/dashboards/TubeTK-${SITE_CTEST_MODE}-${SITE_BUILD_TYPE}" )
 
 set( TubeTK_USE_BOOST OFF )
 set( TubeTK_USE_CTK OFF )

--- a/Krull_Kitware_TubeTK_Nightly.sh
+++ b/Krull_Kitware_TubeTK_Nightly.sh
@@ -9,7 +9,8 @@ echo "Running TubeTK Dashboard script"
 if [ $# -eq 0 ] || [ "$1" != "NoUpdate" ]; then
 
   echo "Updating"
-  rm -rf ${DashboardDir}/TubeTK-${BuildType}
+  rm -rf ${DashboardDir}/TubeTK-Nightly-${BuildType}
+  rm -rf ${DashboardDir}/TubeTK-Continuous-${BuildType}
 
   # Update Dashboard repository
   cd ${DashboardDir}/TubeTK-DashboardScripts


### PR DESCRIPTION
@aylward, can we try different binary directories for the continuous and nightly? Sometimes the Valgrind tests take so long that they are affecting the continuous builds. Since Eternia is running debug builds, it takes the longest and I think that is why the nightly cache file is being overwritten by the continuous cache file.
