### PR TITLE
BUG: Update Deathstar Win7VM CMake path.

### DIFF
--- a/Deathstar_Win7VM_Kitware_TubeTK.cmake
+++ b/Deathstar_Win7VM_Kitware_TubeTK.cmake
@@ -62,9 +62,9 @@ set( BUILD_DOCUMENTATION OFF )
 set( BUILD_SHARED_LIBS ON )
 
 set( SITE_MAKE_COMMAND "${CTEST_BUILD_COMMAND}" )
-set( SITE_CMAKE_COMMAND "C:/Program Files/CMake 2.8/bin/cmake" )
+set( SITE_CMAKE_COMMAND "C:/Program Files (x86)/CMake/bin/cmake" )
 set( SITE_QMAKE_COMMAND "C:/Users/matt/Qt474/bin/qmake" )
-set( SITE_CTEST_COMMAND "C:/Program Files/CMake 2.8/bin/ctest" )
+set( SITE_CMAKE_COMMAND "C:/Program Files (x86)/CMake/bin/ctest" )
 
 set( SITE_MEMORYCHECK_COMMAND "" )
 set( SITE_COVERAGE_COMMAND "" )

--- a/Deathstar_Win7VM_Kitware_TubeTK_Nightly.bat
+++ b/Deathstar_Win7VM_Kitware_TubeTK_Nightly.bat
@@ -8,4 +8,4 @@ REM "C:\Program Files (x86)\Git\bin\git" reset --hard HEAD
 cd ..
 
 REM Run the nightly CTest
-"C:\Program Files (x86)\CMake 2.8\bin\ctest.exe" -S "C:\Dashboards\TubeTK\TubeTK-DashboardScripts\Deathstar_Win7VM_Kitware_TubeTK.cmake" -O "C:\Dashboards\TubeTK\TubeTK_CDashClient_Nightly_log.txt"
+"C:\Program Files (x86)\CMake\bin\ctest.exe" -S "C:\Dashboards\TubeTK\TubeTK-DashboardScripts\Deathstar_Win7VM_Kitware_TubeTK.cmake" -O "C:\Dashboards\TubeTK\TubeTK_CDashClient_Nightly_log.txt"


### PR DESCRIPTION
The CMake path was updated for the CMake 3.X version bump.