### PR TITLE
BUG: Example dashboard directory was inconsistent with actual directo…

### DIFF
--- a/EXAMPLE_TubeTK_OSX_Linux.cmake
+++ b/EXAMPLE_TubeTK_OSX_Linux.cmake
@@ -38,9 +38,9 @@ set( SITE_CMAKE_GENERATOR "Ninja" ) # Ninja or Unix Makefiles
 
 set( TubeTK_GIT_REPOSITORY "https://github.com/KitwareMedical/TubeTK.git" )
 
-set( TubeTK_SOURCE_DIR "/Users/aylward/src/TubeTK" )
+set( TubeTK_SOURCE_DIR "/Users/aylward/src/dashboards/TubeTK" )
 set( TubeTK_BINARY_DIR
-  "/Users/aylward/src/TubeTK-Dashboard-${SITE_BUILD_TYPE}" )
+  "/Users/aylward/src/dashboards/TubeTK-Dashboard-${SITE_BUILD_TYPE}" )
 
 #
 # To work with Slicer and ITK, TubeTK must be built with shared libs

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Get a copy of all the dashboard scripts from the Git repository, including some 
 
 This is the script that will update and launch your dashboard client every night. Use the `.bat` file if you are doing this on Microsoft Windows.
 
-    $ cp TubeTK-DashboardScripts/EXAMPLE_TubeTK_Nightly.sh MyMachine_TubeTK_Nightly.sh
+    $ cd TubeTK-DashboardScripts
+    $ cp EXAMPLE_TubeTK_Nightly.sh MyMachine_TubeTK_Nightly.sh
 
 Setup your machine's parameters as described in the file.
 


### PR DESCRIPTION
…ry used

Dashboard directory used in the example files was ~/src but all scripts
used on dashboard machines are using ~/src/dashboards.
Correction of inconsistent information in README.md. Copy new files
outside of git repository was done twice, but new files were not added
to git repository.