### PR TITLE
BUG: TubeTK_TEST_ENVIRONMENT not set

### DIFF
--- a/MicroTumorLinux1_Amazon_TubeTK.cmake
+++ b/MicroTumorLinux1_Amazon_TubeTK.cmake
@@ -136,6 +136,7 @@ set( TubeTK_USE_PYTHON ON )
 set( TubeTK_USE_QT ON )
 set( TubeTK_USE_VALGRIND ON )
 set( TubeTK_USE_VTK ON )
+set( TubeTK_TEST_ENVIRONMENT OFF)
 
 #
 # Configure what is run on this machine for experimental, continuous, and 

--- a/MicroTumorLinux1_Amazon_TubeTK.cmake
+++ b/MicroTumorLinux1_Amazon_TubeTK.cmake
@@ -136,7 +136,7 @@ set( TubeTK_USE_PYTHON ON )
 set( TubeTK_USE_QT ON )
 set( TubeTK_USE_VALGRIND ON )
 set( TubeTK_USE_VTK ON )
-set( TubeTK_TEST_ENVIRONMENT OFF)
+set( TubeTK_TEST_ENVIRONMENT ON)
 
 #
 # Configure what is run on this machine for experimental, continuous, and 

--- a/MicroTumorLinux1_Amazon_TubeTK_Nightly-Debug.sh
+++ b/MicroTumorLinux1_Amazon_TubeTK_Nightly-Debug.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Trolltech/Qt-4.8.7/lib
+export ITK_BUILD_DIR=$HOME/src/dashboards/TubeTK-Debug-build/ITK-build
+export TubeTK_BUILD_DIR=$HOME/src/dashboards/TubeTK-Debug-build/TubeTK-build
 
 MachineName=MicroTumorLinux1_Amazon
 BuildType=Debug

--- a/MicroTumorLinux1_Amazon_TubeTK_Nightly-Release.sh
+++ b/MicroTumorLinux1_Amazon_TubeTK_Nightly-Release.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Trolltech/Qt-4.8.7/lib
+export ITK_BUILD_DIR=$HOME/src/dashboards/TubeTK-Release-build/ITK-build
+export TubeTK_BUILD_DIR=$HOME/src/dashboards/TubeTK-Release-build/TubeTK-build
 
 MachineName=MicroTumorLinux1_Amazon
 BuildType=Release

--- a/MicroTumorLinux1_Amazon_TubeTK_Slicer.cmake
+++ b/MicroTumorLinux1_Amazon_TubeTK_Slicer.cmake
@@ -136,7 +136,7 @@ set( TubeTK_USE_PYTHON ON )
 set( TubeTK_USE_QT ON )
 set( TubeTK_USE_VALGRIND OFF )
 set( TubeTK_USE_VTK ON )
-set( TubeTK_TEST_ENVIRONMENT OFF)
+set( TubeTK_TEST_ENVIRONMENT ON)
 
 #
 # Configure what is run on this machine for experimental, continuous, and 

--- a/MicroTumorLinux1_Amazon_TubeTK_Slicer_Nightly.sh
+++ b/MicroTumorLinux1_Amazon_TubeTK_Slicer_Nightly.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Trolltech/Qt-4.8.7/lib
+export ITK_BUILD_DIR=$HOME/src/Slicer-SuperBuild-Release/ITKv4-build
+export TubeTK_BUILD_DIR=$HOME/src/dashboards/TubeTK-Slicer-Release/TubeTK-build
 
 MachineName=MicroTumorLinux1_Amazon
 BuildType=Release


### PR DESCRIPTION
On dashboards, TubeTK_TEST_ENVIRONMENT should be set to OFF
as it is expected that the environment variables on the system
may not have the same value as what the TubeTK configuration
system would expect. This is due to the fact that multiple
versions of TubeTK are typically configured and compiled
on one dashboard machine. This test is only useful for
developers to warn them that something could be wrong on
their machines if they have environment variables set
for ITK_BUILD_DIR and TUBETK_BUILD_DIR.