### PR TITLE
ENH: Adding TubeTK_TEST_ENVIRONMENT test on MicroTumorWindows1_Amazon

### DIFF
--- a/MicroTumorWindows1_Amazon_TubeTK.cmake
+++ b/MicroTumorWindows1_Amazon_TubeTK.cmake
@@ -130,7 +130,7 @@ set( TubeTK_USE_PYTHON ON )
 set( TubeTK_USE_QT ON )
 set( TubeTK_USE_VALGRIND OFF )
 set( TubeTK_USE_VTK ON )
-set( TubeTK_TEST_ENVIRONMENT OFF)
+set( TubeTK_TEST_ENVIRONMENT ON)
 
 #
 # Configure what is run on this machine for experimental, continuous, and 

--- a/MicroTumorWindows1_Amazon_TubeTK_Nightly.bat
+++ b/MicroTumorWindows1_Amazon_TubeTK_Nightly.bat
@@ -1,6 +1,10 @@
 REM Start from a clean build directory
 rmdir /Q /S C:\src\dashboards\TubeTK-Release
 
+REM Set environment variables
+set ITK_BUILD_DIR=C:\src\dashboards\TubeTK-Release\ITK-build
+set TubeTK_BUILD_DIR=C:\src\dashboards\TubeTK-Release\TubeTK-build
+
 REM Update the TubeTK Dashboard scripts
 cd C:\src\dashboards\TubeTK-DashboardScripts
 "C:\Program Files\Git\cmd\git" reset --hard HEAD

--- a/MicroTumorWindows1_Amazon_TubeTK_Slicer.cmake
+++ b/MicroTumorWindows1_Amazon_TubeTK_Slicer.cmake
@@ -130,7 +130,7 @@ set( TubeTK_USE_PYTHON ON )
 set( TubeTK_USE_QT ON )
 set( TubeTK_USE_VALGRIND OFF )
 set( TubeTK_USE_VTK ON )
-set( TubeTK_TEST_ENVIRONMENT OFF)
+set( TubeTK_TEST_ENVIRONMENT ON)
 
 #
 # Configure what is run on this machine for experimental, continuous, and 

--- a/MicroTumorWindows1_Amazon_TubeTK_Slicer_Nightly.bat
+++ b/MicroTumorWindows1_Amazon_TubeTK_Slicer_Nightly.bat
@@ -1,9 +1,13 @@
 REM Start from a clean build directory
 rmdir /Q /S C:\src\dashboards\TubeTK-Slicer-Release
 
+REM Set environment variables
+set ITK_BUILD_DIR=C:\src\Slicer-SuperBuild-Release\ITKv4-build
+set TubeTK_BUILD_DIR=C:\src\dashboards\TubeTK-Slicer-Release\TubeTK-build
+
 REM Update the TubeTK Dashboard scripts
 cd C:\src\dashboards\TubeTK-DashboardScripts
-"C:\Program Files\Git\cmd\git reset --hard HEAD
+"C:\Program Files\Git\cmd\git" reset --hard HEAD
 "C:\Program Files\Git\cmd\git" pull
 rename C:\src\dashboards\MicroTumorWindows1_Amazon_TubeTK_Slicer_Nightly.bat C:\src\dashboards\MicroTumorWindows1_Amazon_TubeTK_Slicer_Nightly.bat.old
 copy MicroTumorWindows1_Amazon_TubeTK_Slicer_Nightly.bat C:\src\dashboards\MicroTumorWindows1_Amazon_TubeTK_Slicer_Nightly.bat


### PR DESCRIPTION
TubeTK_TEST_ENVIRONMENT test fails if environment variables ITK_BUILD_DIR
and TubeTK_BUILD_DIR are not set to value that match the current TubeTK
build directory configuration. This test was disabled on MicroTumorWindows1_Amazon
since the environment variables were not set. The environment variables are
now set in the *bat script that starts the configuration of each build
of the project. TubeTK_TEST_ENVIRONMENT should pass and therefore the test
is enabled.